### PR TITLE
Added offset support for SH1106 132x64 controller with 128x64 matrix

### DIFF
--- a/src/oled.cpp
+++ b/src/oled.cpp
@@ -403,6 +403,10 @@ void OLED::display()
         i2c_start();
         i2c_send(i2c_address << 1); // address + write
         i2c_send(0x40); // data
+        if(usingOffset){
+            i2c_send(0);
+            i2c_send(0);
+        }
         for (uint_fast8_t column = 0; column < width; column++)
         {
             i2c_send(buffer[index++]);
@@ -986,4 +990,12 @@ size_t OLED::write(const uint8_t *buffer, size_t len)
 void OLED::setTTYMode(bool Enabled)
 {
 	ttyMode=Enabled;
+}
+
+
+void OLED::useOffset(bool offset)
+{
+    if(isSH1106){
+        usingOffset = offset;
+    }
 }

--- a/src/oled.h
+++ b/src/oled.h
@@ -98,6 +98,11 @@ public:
      * Initialize the display controller, clean memory and switch output on.
      */
     void begin();
+
+    /**
+     * Will use offset for wired cases when controller uses SSH1106 132x64 but display is 128x64
+     */
+    void useOffset(bool offset=true);
     
     /**
      * Enable or disable the charge pump and display output. May be used to save power.
@@ -336,6 +341,9 @@ private:
     
     /** true=SH1106 controller, false=SSD1306 controller  */
     const bool isSH1106;
+
+    /** Offset for SH1106 132x64 controller with 128x64 matrix */
+    bool usingOffset;
     
     /** Number of pages in the display and buffer */
     const uint_fast8_t pages;


### PR DESCRIPTION
Hey Fabio,
I bought a strange SH1106 module with 132x64 controller and 128x64 matrix.
In this weird scenario controller "centers" the matrix, which results in 2 pixels missing on the left: (0,y) and (1,y).
Had to fix it manually, so here are my changes.
Let me know what you think of that and if there is anything else to check.
Regards,
Andrew